### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -7,7 +7,7 @@ output:
     variant: markdown_github
 ---
 
-[![DOI](https://zenodo.org/badge/5630/hrbrmstr/resolv.png)](http://dx.doi.org/10.5281/zenodo.11343)
+[![DOI](https://zenodo.org/badge/5630/hrbrmstr/resolv.png)](https://doi.org/10.5281/zenodo.11343)
 
 resolv
 ======

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/5630/hrbrmstr/resolv.png)](http://dx.doi.org/10.5281/zenodo.11343)
+[![DOI](https://zenodo.org/badge/5630/hrbrmstr/resolv.png)](https://doi.org/10.5281/zenodo.11343)
 
 resolv
 ======


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!